### PR TITLE
fix: wait until TRML framework is done processing before screenshotting

### DIFF
--- a/app/aspects/screens/shoter.rb
+++ b/app/aspects/screens/shoter.rb
@@ -42,7 +42,21 @@ module Terminus
           Pathname.mktmpdir do |work_dir|
             page.content = work_dir.join("content.html").write(content).read
             page.set_viewport(**viewport)
-            page.network.wait_for_idle duration: 5
+
+            # Continuously check until `TRMNL_PLUGINS_READY` has been set to true.
+            # The framework's plugin.js does that once it's done with its work
+            # (like handling overflow etc.)
+            wait = <<~EOT
+              const resolve = arguments[0];
+              const interval = setInterval(() => {
+                if (window.TRMNL_PLUGINS_READY) {
+                  clearInterval(interval);
+                  resolve();
+                }
+              }, 100);
+            EOT
+
+            page.evaluate_async(wait, 10)
             page.screenshot path: output_path.to_s
           end
 


### PR DESCRIPTION
I'm regularly seeing the issue where the generated screen hasn't had the overflow logic applied. This is the same issue as in #324, except that it's not consistent -- sometimes it works, sometimes it doesn't.

That previous report was meant to be fixed by 556d10e359d63883d2a88e4bc1b66e8b719a2074, but that change only increases the delay *if there were network connections to begin with*:

https://github.com/rubycdp/ferrum/blob/9fae889c724ab4388bee2c5f54a440e0e095b86a/lib/ferrum/network.rb#L65

I assume that when I see overflowed columns, either the network traffic was very quick (already done in time for the first check), delayed (not yet started and therefore appearing idle), or not happening at all (and instead served by some caching layer).

My change here replaces the reliance on timeouts and network checks with a check whether the Framework's JS is done performing its duties.

When it is, it sets `window.TRMNL_PLUGINS_READY` to `true`, so we can continuously check for that value (every 0.1 seconds) until it's been set.

Full disclosure: This behavior of the Framework is not documented as far as I can tell -- I got this purely from inspecting https://trmnl.com/js/latest/plugins.js.

But given that you're sitting at the source (literally 😄), I'm sure you can judge whether this approach is reliable or if there's a better way.
