### PR TITLE
Add GitHub Releases workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          make_latest: true


### PR DESCRIPTION
## Problem

Terminus publishes **Git tags only** — no GitHub Releases. This works for Docker (the `docker.yml` workflow triggers on tags), but causes friction for packaging ecosystems that consume releases via the standard GitHub Releases API:

- **ProxmoxVED** (community-scripts/ProxmoxVED) — an LXC script framework for Proxmox VE — requires GitHub Releases to use `fetch_and_deploy_gh_release` / `check_for_gh_release`. Without releases, their CI auto-rejects new script submissions that can't use these functions. A Terminus LXC script PR was auto-closed for this reason: https://github.com/community-scripts/ProxmoxVED/pull/2158
- Other packagers (Home Assistant add-ons, CasaOS, Umbrel, etc.) typically expect GitHub Releases as well.

## Solution

Add a minimal `release.yml` workflow that creates a GitHub Release for every tag push, with auto-generated release notes from commit history.

**What changes:**
- New file: `.github/workflows/release.yml` (~20 lines)
- Triggers on: `push.tags: ["*"]` (same trigger as `docker.yml`)
- Uses: `softprops/action-gh-release@v2` (most widely used release action)
- Release notes: auto-generated by GitHub from commits since last release
- No artifacts attached (source tarball/zipball is automatic via GitHub)

**What doesn't change:**
- Existing `docker.yml` workflow — untouched
- Tag pattern — stays `0.68.0` (no `v` prefix needed)
- Release notes are auto-generated, no manual changelog required

## Compatibility

- Tags without `v` prefix work (`softprops/action-gh-release` handles both)
- The workflow runs in parallel with `docker.yml` (both trigger on tags)
- `permissions: contents: write` is required and sufficient for creating releases
- `GITHUB_TOKEN` (automatic in Actions) is used — no additional secrets needed

## Retroactive Releases (optional)

Existing tags (0.49.0 → 0.68.0) won't get retroactive releases automatically. If desired, the maintainers can create releases for past tags manually, or run a one-time script to backfill. This is optional — new releases going forward is the priority.